### PR TITLE
Delete .url shortcuts

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Michael Kropat
+Copyright (c) 2021 Michael Kropat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/TidyDesktopMonster/Logging/RotatingBufferSink.cs
+++ b/TidyDesktopMonster/Logging/RotatingBufferSink.cs
@@ -24,7 +24,7 @@ namespace TidyDesktopMonster.Logging
             if (_end == _start)
                 _start = (_start + 1) % _entries.Length;
 
-            SubjectChanged(this, new EventArgs());
+            SubjectChanged?.Invoke(this, new EventArgs());
         }
 
         public IEnumerable<LogEntry> GetSubjects()

--- a/TidyDesktopMonster/Program.cs
+++ b/TidyDesktopMonster/Program.cs
@@ -114,16 +114,20 @@ namespace TidyDesktopMonster
         {
             var allUsersDesktop = Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory);
             var currentUserDesktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            var searchPattern = "*.lnk";
 
             return settingsStore.Read<bool?>(Constants.TidyAllUsersSetting) == true
-                ? (IUpdatingSubject<string>)new CompositeSubject<string>(new[]
+                ? new CompositeSubject<string>(new[]
                 {
-                    new FilesInDirectorySubject(allUsersDesktop, searchPattern),
-                    new FilesInDirectorySubject(currentUserDesktop, searchPattern),
-
+                    new FilesInDirectorySubject(allUsersDesktop, "*.lnk"),
+                    new FilesInDirectorySubject(allUsersDesktop, "*.url"),
+                    new FilesInDirectorySubject(currentUserDesktop, "*.lnk"),
+                    new FilesInDirectorySubject(currentUserDesktop, "*.url"),
                 })
-                : new FilesInDirectorySubject(currentUserDesktop, searchPattern);
+                : new CompositeSubject<string>(new[]
+                {
+                    new FilesInDirectorySubject(currentUserDesktop, "*.lnk"),
+                    new FilesInDirectorySubject(currentUserDesktop, "*.url"),
+                });
         }
 
         static bool PathHasExtension(string path, string[] extensions)

--- a/TidyDesktopMonster/Properties/AssemblyInfo.cs
+++ b/TidyDesktopMonster/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TidyDesktopMonster")]
-[assembly: AssemblyCopyright("Copyright © Michael Kropat 2017")]
+[assembly: AssemblyCopyright("Copyright © Michael Kropat 2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.4.*")]
+[assembly: AssemblyVersion("0.3.0.*")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TidyDesktopMonster/TidyDesktopMonster.csproj
+++ b/TidyDesktopMonster/TidyDesktopMonster.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\ILMerge.3.0.41\build\ILMerge.props" Condition="Exists('..\packages\ILMerge.3.0.41\build\ILMerge.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -161,11 +164,17 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <ILMergeConsolePath>$(SolutionDir)packages\ILMerge.2.14.1208\tools\ILMerge.exe</ILMergeConsolePath>
+    <ILMergeConsolePath>$(SolutionDir)packages\ILMerge.3.0.41\tools\net452\ILMerge.exe</ILMergeConsolePath>
     <BinOutputDir>$(SolutionDir)Bin\$(Configuration)\</BinOutputDir>
   </PropertyGroup>
   <Target Name="ILMerge" AfterTargets="Build">
     <MakeDir Directories="$(BinOutputDir)" />
     <Exec Command="$(ILMergeConsolePath) /out:$(BinOutputDir)TidyDesktopMonster.exe $(TargetDir)TidyDesktopMonster.exe $(TargetDir)ShellifyLib.dll" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILMerge.3.0.41\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILMerge.3.0.41\build\ILMerge.props'))" />
   </Target>
 </Project>

--- a/TidyDesktopMonster/WinApi/FilesInDirectorySubject.cs
+++ b/TidyDesktopMonster/WinApi/FilesInDirectorySubject.cs
@@ -11,7 +11,7 @@ namespace TidyDesktopMonster.WinApi
         readonly string _pattern;
         readonly FileSystemWatcher _watcher;
 
-        public FilesInDirectorySubject(string directoryPath, string searchPattern = "*.*")
+        public FilesInDirectorySubject(string directoryPath, string searchPattern = "")
         {
             _directory = directoryPath;
             _pattern = searchPattern;

--- a/TidyDesktopMonster/packages.config
+++ b/TidyDesktopMonster/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
+  <package id="ILMerge" version="3.0.41" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The Epic store creates .url shortcut files to all the games it installs, which I'd like tidied up.

It seems like Shellify lib isn't able to read the .url files, so it's not currently possible to support the .url file type for "App Shortcuts"
filtering. If you want .url files to be deleted, you must use the "All Shortcuts" setting.